### PR TITLE
.gitignoreにcork.shとfix.shを追加

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -22,4 +22,5 @@ yarn-error.log
 /.nova
 /.vscode
 /.zed
-
+cork.sh
+fix.sh


### PR DESCRIPTION
.gitignoreファイルに記述されたファイルは、git addとかされないで無視されるようになります。

今回cork.sh(ついでにfix.sh)を追加した理由は、cork.shを各自で作成し、そこにdocker compose upからの流れを記述しちゃえば毎朝すぐに作業する体制に移れるようになるからです。

以下がcork.shの例です。
```
#!/bin/bash
 
PROJECT_PATH=~/Corkboard/Corkboard
 
# プロジェクトに移動
cd $PROJECT_PATH || exit
 
# VSCodeを開く
code .
 
# Dockerを起動
docker compose up -d
 
# Git masterブランチを最新に
    git checkout main
    git pull origin main
 
# コンテナ内でnpm run devを実行
docker compose exec app bash -c "npm run dev"
 
echo ""
echo "Docker起動＆Git main更新・npm run dev が完了しました！"
echo "この後絶対ブランチ作成や切り替えしてね！（例：git checkout -b something）"

```